### PR TITLE
Added first_load_arrival_date / event_date fields

### DIFF
--- a/signal_ocean/voyages/models.py
+++ b/signal_ocean/voyages/models.py
@@ -109,6 +109,8 @@ class VoyageEvent:
             EventType="VoyageStart". If the event is a portcall, that is an
             operational stop, this field specifies the type of operation, like
             "Load", "Discharge" or "Dry dock".
+        event_date: Date, format YYYY-MM-DD HH:MM:SS. The timestamp of the 
+            specific event, for instantaneous events e.g. VoyageStart
         arrival_date: Date, format YYYY-MM-DD HH:MM:SS. The beginning of the
             specific event. The arrival date of an event is calculated based on
             the first AIS point within the event. In the case of missing AIS
@@ -194,6 +196,7 @@ class VoyageEvent:
     event_type: Optional[str] = None
     event_horizon: Optional[str] = None
     purpose: Optional[str] = None
+    event_date: Optional[datetime] = None
     arrival_date: Optional[datetime] = None
     sailing_date: Optional[datetime] = None
     latitude: Optional[float] = None
@@ -268,6 +271,9 @@ class Voyage:
             previous voyage (if existing) or the first received AIS (for a new
             building). Voyages are consecutive and with no breaks in between,
             therefore a vessel is always in a voyage.
+        first_load_arrival_date: Date, format YYYY-MM-DD HH:MM:SS. The time 
+            of arrival for the first load in the voyage. Indicates the 
+            transition from Ballast to Laden.
         end_date: Date, format YYYY-MM-DD HH:MM:SS. The end of the specific
             voyage. The end of a voyage is set as the sailing date (or
             completion date) from the port where the vessel discharged for the
@@ -343,6 +349,7 @@ class Voyage:
     vessel_status: Optional[str] = None
     commercial_operator: Optional[str] = None
     start_date: Optional[datetime] = None
+    first_load_arrival_date: Optional[datetime] = None
     end_date: Optional[datetime] = None
     charterer_id: Optional[int] = None
     charterer: Optional[str] = None

--- a/signal_ocean/voyages/models.py
+++ b/signal_ocean/voyages/models.py
@@ -109,7 +109,7 @@ class VoyageEvent:
             EventType="VoyageStart". If the event is a portcall, that is an
             operational stop, this field specifies the type of operation, like
             "Load", "Discharge" or "Dry dock".
-        event_date: Date, format YYYY-MM-DD HH:MM:SS. The timestamp of the 
+        event_date: Date, format YYYY-MM-DD HH:MM:SS. The timestamp of the
             specific event, for instantaneous events e.g. VoyageStart
         arrival_date: Date, format YYYY-MM-DD HH:MM:SS. The beginning of the
             specific event. The arrival date of an event is calculated based on
@@ -271,8 +271,8 @@ class Voyage:
             previous voyage (if existing) or the first received AIS (for a new
             building). Voyages are consecutive and with no breaks in between,
             therefore a vessel is always in a voyage.
-        first_load_arrival_date: Date, format YYYY-MM-DD HH:MM:SS. The time 
-            of arrival for the first load in the voyage. Indicates the 
+        first_load_arrival_date: Date, format YYYY-MM-DD HH:MM:SS. The time
+            of arrival for the first load in the voyage. Indicates the
             transition from Ballast to Laden.
         end_date: Date, format YYYY-MM-DD HH:MM:SS. The end of the specific
             voyage. The end of a voyage is set as the sailing date (or


### PR DESCRIPTION
Two new fields exposed through the VoyageData API:
- **first_load_arrival_date**: The arrival date of the first load has been added to the root level to easily calculate ballast leg of the voyage.
- **event_date**:  The timestamp of the specific event, for instantaneous events e.g. VoyageStart
