### PR TITLE
Adding extra information about voyage on the response

### DIFF
--- a/signal_ocean/voyages/models.py
+++ b/signal_ocean/voyages/models.py
@@ -331,6 +331,9 @@ class Voyage:
             voyage.
         is_implied_by_ais: Boolean. This will be true if the voyage is implied
             from AIS.
+        has_manual_entries: Boolean.
+        ballast_distance: Numeric.
+        laden_distance: Numeric.
     """
     imo: int
     voyage_number: int
@@ -371,6 +374,9 @@ class Voyage:
     fixture_is_coa: Optional[bool] = None
     fixture_is_hold: Optional[bool] = None
     is_implied_by_ais: Optional[bool] = None
+    has_manual_entries: Optional[bool] = None
+    ballast_distance: Optional[float] = None
+    laden_distance: Optional[float] = None
 
 
 @dataclass(frozen=True)

--- a/signal_ocean/voyages/models.py
+++ b/signal_ocean/voyages/models.py
@@ -332,7 +332,7 @@ class Voyage:
         is_implied_by_ais: Boolean. This will be true if the voyage is implied
             from AIS.
         has_manual_entries: Boolean. True if the fused matched fixture on a
-            voyage contains at least one (partial or full) fixture input by a 
+            voyage contains at least one (partial or full) fixture input by a
             user. It indicates that there is additional information input by a
             user in addition to what received through market reports only.
         ballast_distance: Numeric. Distance in nautical miles between the last

--- a/signal_ocean/voyages/models.py
+++ b/signal_ocean/voyages/models.py
@@ -331,9 +331,16 @@ class Voyage:
             voyage.
         is_implied_by_ais: Boolean. This will be true if the voyage is implied
             from AIS.
-        has_manual_entries: Boolean.
-        ballast_distance: Numeric.
-        laden_distance: Numeric.
+        has_manual_entries: Boolean. True if the fused matched fixture on a
+            voyage contains at least one (partial or full) fixture input by a 
+            user. It indicates that there is additional information input by a
+            user in addition to what received through market reports only.
+        ballast_distance: Numeric. Distance in nautical miles between the last
+            discharge port and the first load port. It is computed based on
+            past AIS data
+        laden_distance: Numeric. Distance in nautical miles between the first
+            load port and the last discharge port. It is computed based on past
+            AIS data
     """
     imo: int
     voyage_number: int


### PR DESCRIPTION
Three new fields have been added in the response at the root level of the voyage as follows:

- **HasManualEntries**: Boolean. True if the fused matched fixture on a voyage contains at least one (partial or full) fixture input by a user. It indicates that there is additional information input by a user in addition to what received through market reports only.
- **BallastDistance**: Distance in nautical miles between the last discharge port and the first load port. It is computed based on past AIS data
- **LadenDistance**: Distance in nautical miles between the first load port and the last discharge port. It is computed based on past AIS data