### PR TITLE
Updated descriptions of BallastDistance/LadenDistance

### DIFF
--- a/signal_ocean/voyages/models.py
+++ b/signal_ocean/voyages/models.py
@@ -335,12 +335,14 @@ class Voyage:
             voyage contains at least one (partial or full) fixture input by a
             user. It indicates that there is additional information input by a
             user in addition to what received through market reports only.
-        ballast_distance: Numeric. Distance in nautical miles between the last
-            discharge port and the first load port. It is computed based on
-            past AIS data
-        laden_distance: Numeric. Distance in nautical miles between the first
-            load port and the last discharge port. It is computed based on past
-            AIS data
+        ballast_distance: Numeric. Travelled distance in nautical miles between
+            the last discharge port of the previous voyage and the first load
+            port of the current voyage. It is computed based on AIS data.
+            It includes the whole period between the two port calls and non
+            operational stops as well. Accuracy depends on AIS coverage.
+        laden_distance: Numeric. Travelled distance in nautical miles between
+            the first load port and the last discharge port of the same voyage.
+            It is computed based on AIS data. Accuracy depends on AIS coverage.
     """
     imo: int
     voyage_number: int


### PR DESCRIPTION
Updated description of voyages object for the below fields:
- **BallastDistance**: Travelled distance in nautical miles between the last discharge port of the previous voyage and the first load port of the current voyage. It is computed based on AIS data. It includes the whole period between the two port calls and non operational stops as well. Accuracy depends on AIS coverage.
- **LadenDistance**: Travelled distance in nautical miles between the first load port and the last discharge port of the same voyage. It is computed based on AIS data. Accuracy depends on AIS coverage.