### PR TITLE
Correct fixtures colab link

### DIFF
--- a/docs/examples/jupyter/ScrapedFixturesAPI/Scraped Fixtures API Example.ipynb
+++ b/docs/examples/jupyter/ScrapedFixturesAPI/Scraped Fixtures API Example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Scraped Fixtures API Example\n",
     "\n",
-    "## Run this example in [Colab](https://signaloceansdk.github.io/SignalSDK/examples/jupyter/ScrapedFixturesAPI/Scraped%20Fixtures%20API%20Example/)"
+    "## Run this example in [Colab](https://colab.research.google.com/github/SignalOceanSdk/SignalSDK/blob/master/docs/examples/jupyter/ScrapedFixturesAPI/Scraped%20Fixtures%20API%20Example.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
- Correct colab link in Scraped Fixtures API Example notebook