### PR TITLE
Fix breaking type changes and document _ACRONYMS limitation

### DIFF
--- a/docs/examples/jupyter/Combined Examples/MR2_ARA_Supply_versus_Market_Rates.ipynb
+++ b/docs/examples/jupyter/Combined Examples/MR2_ARA_Supply_versus_Market_Rates.ipynb
@@ -1779,6 +1779,15 @@
       "source": [
         "plot_drawing()"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "connection.close()"
+      ]
     }
   ],
   "metadata": {

--- a/docs/examples/jupyter/Combined Examples/Supply trend with market rates.ipynb
+++ b/docs/examples/jupyter/Combined Examples/Supply trend with market rates.ipynb
@@ -615,6 +615,15 @@
      "name": "#%%\n"
     }
    }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Combined Examples/VLCCs_MEG_China_Supply_Trend_Versus_Market_Rates_with_Implementing_Filters.ipynb
+++ b/docs/examples/jupyter/Combined Examples/VLCCs_MEG_China_Supply_Trend_Versus_Market_Rates_with_Implementing_Filters.ipynb
@@ -1598,6 +1598,15 @@
         "plt.tight_layout()  # Adjust layout to make room for labels\n",
         "plt.show()"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "connection.close()"
+      ]
     }
   ],
   "metadata": {

--- a/docs/examples/jupyter/CompaniesAPI/CompaniesAPI.ipynb
+++ b/docs/examples/jupyter/CompaniesAPI/CompaniesAPI.ipynb
@@ -868,6 +868,15 @@
    "source": [
     "df[df['company_name'].str.startswith('Signal')]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/DistancesAPI/AlternativeRoutes.ipynb
+++ b/docs/examples/jupyter/DistancesAPI/AlternativeRoutes.ipynb
@@ -150,6 +150,15 @@
     "\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/DistancesAPI/DistancesWithRouteExample.ipynb
+++ b/docs/examples/jupyter/DistancesAPI/DistancesWithRouteExample.ipynb
@@ -172,6 +172,15 @@
     "\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/DistancesAPI/QuickStartDistancesAPI.ipynb
+++ b/docs/examples/jupyter/DistancesAPI/QuickStartDistancesAPI.ipynb
@@ -206,6 +206,15 @@
     "df.to_excel('simpleDistanceMatrix_Trieste_Aframax_Ballast.xlsx')\n",
     "df"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/FreightRatesAPI/FreightRatesAPI.ipynb
+++ b/docs/examples/jupyter/FreightRatesAPI/FreightRatesAPI.ipynb
@@ -236,6 +236,15 @@
      "name": "#%%\n"
     }
    }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/GeosAPI/GeosAPI Use Case.ipynb
+++ b/docs/examples/jupyter/GeosAPI/GeosAPI Use Case.ipynb
@@ -563,6 +563,15 @@
    "source": [
     "df_geoAssets.head(10)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/MarketRatesAPI/MarketRatesAPI.ipynb
+++ b/docs/examples/jupyter/MarketRatesAPI/MarketRatesAPI.ipynb
@@ -250,6 +250,15 @@
    },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/PortExpensesAPI/PortExpensesAPI.ipynb
+++ b/docs/examples/jupyter/PortExpensesAPI/PortExpensesAPI.ipynb
@@ -295,6 +295,15 @@
      "name": "#%%\n"
     }
    }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/ScrapedCargoesAPI/Historical Cargo Distribution in Area Level leveraging Geos API.ipynb
+++ b/docs/examples/jupyter/ScrapedCargoesAPI/Historical Cargo Distribution in Area Level leveraging Geos API.ipynb
@@ -5544,6 +5544,15 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/ScrapedCargoesAPI/Scraped Cargoes API Example.ipynb
+++ b/docs/examples/jupyter/ScrapedCargoesAPI/Scraped Cargoes API Example.ipynb
@@ -1523,6 +1523,15 @@
    },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/ScrapedFixturesAPI/Scraped Fixtures API Example.ipynb
+++ b/docs/examples/jupyter/ScrapedFixturesAPI/Scraped Fixtures API Example.ipynb
@@ -1527,6 +1527,15 @@
    },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/ScrapedLineupsAPI/Scraped Lineups API Example.ipynb
+++ b/docs/examples/jupyter/ScrapedLineupsAPI/Scraped Lineups API Example.ipynb
@@ -1333,6 +1333,15 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/ScrapedPositionsAPI/Scraped Positions API Example.ipynb
+++ b/docs/examples/jupyter/ScrapedPositionsAPI/Scraped Positions API Example.ipynb
@@ -1583,6 +1583,15 @@
    },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Tonnage List API/Finding vessels opening east and west of Suez.ipynb
+++ b/docs/examples/jupyter/Tonnage List API/Finding vessels opening east and west of Suez.ipynb
@@ -226,6 +226,15 @@
     "ax2.set_ylabel(\"Vessel count\")\n",
     "ax2.legend()\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Tonnage List API/Finding vessels that were on subs around Houston.ipynb
+++ b/docs/examples/jupyter/Tonnage List API/Finding vessels that were on subs around Houston.ipynb
@@ -149,6 +149,15 @@
     "ax.set_ylabel(\"Vessel count\")\n",
     "ax.legend()\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Tonnage List API/Finding vessels that were opening at Fos.ipynb
+++ b/docs/examples/jupyter/Tonnage List API/Finding vessels that were opening at Fos.ipynb
@@ -155,6 +155,15 @@
     "ax.set_ylabel(\"Vessel count\")\n",
     "ax.legend()\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Tonnage List API/Historical analysis over all vessels.ipynb
+++ b/docs/examples/jupyter/Tonnage List API/Historical analysis over all vessels.ipynb
@@ -257,6 +257,15 @@
     "ax2.set_ylabel(\"Vessel count\")\n",
     "ax2.legend()\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Tonnage List API/Persisting data in SQLite.ipynb
+++ b/docs/examples/jupyter/Tonnage List API/Persisting data in SQLite.ipynb
@@ -848,6 +848,15 @@
    "source": [
     "data_frame.to_sql(\"htl_ceyhan_aframax\", engine, index=True, if_exists=\"append\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Tonnage List API/Recall live Tonnage List.ipynb
+++ b/docs/examples/jupyter/Tonnage List API/Recall live Tonnage List.ipynb
@@ -202,6 +202,15 @@
    },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/Tonnage List API/Working with the TonnageListAPI.ipynb
+++ b/docs/examples/jupyter/Tonnage List API/Working with the TonnageListAPI.ipynb
@@ -631,6 +631,15 @@
      "name": "#%%\n"
     }
    }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/ValuationsAPI/ValuationsAPIUse-Cases.ipynb
+++ b/docs/examples/jupyter/ValuationsAPI/ValuationsAPIUse-Cases.ipynb
@@ -366,6 +366,15 @@
     "plt.xlabel(\"Valuation Date\", fontsize=14)\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VesselConsumptionsAPI/VesselConsumptionsAPI.ipynb
+++ b/docs/examples/jupyter/VesselConsumptionsAPI/VesselConsumptionsAPI.ipynb
@@ -409,6 +409,15 @@
     "else:\n",
     "    print(\"No data available\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VesselEmissionsAPI/Carbon Analysis.ipynb
+++ b/docs/examples/jupyter/VesselEmissionsAPI/Carbon Analysis.ipynb
@@ -598,6 +598,15 @@
         "plt.title('Cii per Vessel (2024)', fontsize=14)\n",
         "plt.show()"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "connection.close()"
+      ]
     }
   ],
   "metadata": {

--- a/docs/examples/jupyter/VesselEmissionsAPI/EUA_Analysis.ipynb
+++ b/docs/examples/jupyter/VesselEmissionsAPI/EUA_Analysis.ipynb
@@ -1036,6 +1036,15 @@
    "source": [
     "sum(projected_emissions_for_current_year.Estimated_end_of_year_EUAs)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VesselEmissionsAPI/VesselEmissionsAPI-UseCase.ipynb
+++ b/docs/examples/jupyter/VesselEmissionsAPI/VesselEmissionsAPI-UseCase.ipynb
@@ -1008,6 +1008,15 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VesselEmissionsAPI/VesselEmissionsAPI.ipynb
+++ b/docs/examples/jupyter/VesselEmissionsAPI/VesselEmissionsAPI.ipynb
@@ -1219,6 +1219,15 @@
    "source": [
     "vessel_class_metrics_2020 = api.get_metrics_by_vessel_class_id(vessel_class_id=86, year=2020)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VesselsAPI/ExploreVessels.ipynb
+++ b/docs/examples/jupyter/VesselsAPI/ExploreVessels.ipynb
@@ -213,6 +213,15 @@
     "\n",
     "sns.pairplot(data, kind='kde', hue='vessel_class', vars=['deadweight', 'length_overall', 'breadth_extreme']);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VesselsAPI/VesselsAPI.ipynb
+++ b/docs/examples/jupyter/VesselsAPI/VesselsAPI.ipynb
@@ -1354,6 +1354,15 @@
    "source": [
     "df"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/DryBulkFlows.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/DryBulkFlows.ipynb
@@ -2206,6 +2206,15 @@
     "fig.update_layout(bargap=0.2)\n",
     "fig.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/Dry_Capes_Daily_List_Of_Vessels_In_Dry_dock.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/Dry_Capes_Daily_List_Of_Vessels_In_Dry_dock.ipynb
@@ -1490,6 +1490,15 @@
         "daily_list_df = daily_list_df.sort_values(by='date',ascending=False)\n",
         "daily_list_df.to_excel(file_path, index=False)"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "connection.close()"
+      ]
     }
   ],
   "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/FixtureCount.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/FixtureCount.ipynb
@@ -4854,6 +4854,15 @@
     "# Plot the results\n",
     "plot_results(preprocessed_voyages)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/FlowsFromV4.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/FlowsFromV4.ipynb
@@ -1199,6 +1199,15 @@
     "             color_discrete_sequence=[\"lightgray\", \"gray\", \"lightblue\"])\n",
     "fig.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/Get available vessel types, vessel classes, vessels.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/Get available vessel types, vessel classes, vessels.ipynb
@@ -1066,6 +1066,15 @@
    "source": [
     "get_vessels('First')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/OilFlows.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/OilFlows.ipynb
@@ -1996,6 +1996,15 @@
     "fig.update_layout(bargap=0.2)\n",
     "fig.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/VoyagesAPI-FloatingStorages.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/VoyagesAPI-FloatingStorages.ipynb
@@ -693,6 +693,15 @@
     "plt.xticks(rotation = 90)\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/VoyagesAPI-UseCases.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/VoyagesAPI-UseCases.ipynb
@@ -612,6 +612,15 @@
     "ax.set_xlabel('Load Countries', fontsize=12)\n",
     "ax.set_ylabel('Vessel Counts', fontsize=12);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/VoyagesAPI-VoyagesDataLike.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/VoyagesAPI-VoyagesDataLike.ipynb
@@ -927,6 +927,15 @@
    "source": [
     "voyages.to_excel('voyages_data.xlsx', index = False)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/VoyagesAPI.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/VoyagesAPI.ipynb
@@ -2100,6 +2100,15 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/VoyagesAPI_Dry_Last_year_Capesize_Discharges_To_China.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/VoyagesAPI_Dry_Last_year_Capesize_Discharges_To_China.ipynb
@@ -1943,6 +1943,15 @@
         "df['sailing_date'] = df['sailing_date'].dt.tz_localize(None)\n",
         "df.to_excel(file_path, index=False)"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "connection.close()"
+      ]
     }
   ],
   "metadata": {

--- a/docs/examples/jupyter/VoyagesAPI/Voyages_Metrics_Top_3_Loading_Locations_Discharge_Locations_Cargo_Types.ipynb
+++ b/docs/examples/jupyter/VoyagesAPI/Voyages_Metrics_Top_3_Loading_Locations_Discharge_Locations_Cargo_Types.ipynb
@@ -456,6 +456,15 @@
         "plt.tight_layout()\n",
         "plt.show()"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "connection.close()"
+      ]
     }
   ],
   "metadata": {

--- a/docs/examples/jupyter/VoyagesMarketDataAPI/FixtureStatus.ipynb
+++ b/docs/examples/jupyter/VoyagesMarketDataAPI/FixtureStatus.ipynb
@@ -573,6 +573,15 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesMarketDataAPI/RateTrend.ipynb
+++ b/docs/examples/jupyter/VoyagesMarketDataAPI/RateTrend.ipynb
@@ -304,6 +304,15 @@
     "sns.lineplot(data=fixtures[fixtures['Date']>start_date], x='Date', color='red', y='7_days_moving_average').set_title(\"Rate moving average and last done\")\n",
     "sns.scatterplot(data=fixtures[fixtures['Date']>start_date], x='Date', y='rate')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/jupyter/VoyagesMarketDataAPI/VoyagesMarketDataAPIExample.ipynb
+++ b/docs/examples/jupyter/VoyagesMarketDataAPI/VoyagesMarketDataAPIExample.ipynb
@@ -1581,6 +1581,15 @@
     "matched_fixtures = pd.DataFrame([r.matched_fixture.__dict__ for r in result])\n",
     "matched_fixtures.head()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connection.close()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/releases/Version 14.0.0.md
+++ b/docs/releases/Version 14.0.0.md
@@ -6,7 +6,6 @@ Download here: [![PyPI version shields.io](https://img.shields.io/pypi/v/signal-
 - Replaced the internal `parsing_helpers` deserialisation engine with [Pydantic v2](https://docs.pydantic.dev/latest/). All SDK models are now `pydantic.BaseModel` subclasses.
 - Parsing time for large queries reduced by ~70% (from ~27% to ~14% of total wall time on a full `VoyageCondensed` fetch).
 - Effective throughput improved from ~40 req/min to ~150 req/min on the condensed voyages endpoint.
-- `pydantic>=2.0` is now a required dependency.
 
 ## Performance — HTTP Connection Reuse
 
@@ -28,6 +27,7 @@ with Connection() as connection:
 ## Breaking Changes
 
 - **Minimum Python version raised from 3.7 to 3.8.** Python 3.7 reached end-of-life in June 2023 and is no longer supported.
+- **`pydantic>=2.0` is now a required dependency.** All SDK models are now Pydantic `BaseModel` subclasses. If your project pins `pydantic<2`, you will need to upgrade.
 
 ## Installation and Upgrade Notes
 Update your package with: `pip install signal-ocean -U`

--- a/docs/releases/Version 14.0.0.md
+++ b/docs/releases/Version 14.0.0.md
@@ -12,6 +12,18 @@ Download here: [![PyPI version shields.io](https://img.shields.io/pypi/v/signal-
 
 - `Connection` now uses a persistent `requests.Session` for all API calls, eliminating per-request TLS handshake overhead.
 - Throughput on the first benchmark query improved from ~26 req/min to ~40 req/min; combined with the parsing improvements the sustained rate reaches ~155 req/min.
+- `Connection` now supports `close()` and can be used as a context manager. Call `connection.close()` when you are done, or use `with Connection(...) as connection:` to ensure the underlying session is released.
+
+```python
+# Option A — explicit close
+connection = Connection()
+# ... use APIs ...
+connection.close()
+
+# Option B — context manager
+with Connection() as connection:
+    # ... use APIs ...
+```
 
 ## Breaking Changes
 

--- a/docs/releases/Version 14.0.0.md
+++ b/docs/releases/Version 14.0.0.md
@@ -13,5 +13,9 @@ Download here: [![PyPI version shields.io](https://img.shields.io/pypi/v/signal-
 - `Connection` now uses a persistent `requests.Session` for all API calls, eliminating per-request TLS handshake overhead.
 - Throughput on the first benchmark query improved from ~26 req/min to ~40 req/min; combined with the parsing improvements the sustained rate reaches ~155 req/min.
 
+## Breaking Changes
+
+- **Minimum Python version raised from 3.7 to 3.8.** Python 3.7 reached end-of-life in June 2023 and is no longer supported.
+
 ## Installation and Upgrade Notes
 Update your package with: `pip install signal-ocean -U`

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     ],
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: Apache Software License",

--- a/signal_ocean/connection.py
+++ b/signal_ocean/connection.py
@@ -56,10 +56,10 @@ class Connection:
         """Close the underlying session and release connections."""
         self.__session.close()
 
-    def __enter__(self) -> "Connection":
+    def __enter__(self) -> "Connection":  # noqa: D105
         return self
 
-    def __exit__(self, *args: object) -> None:
+    def __exit__(self, *args: object) -> None:  # noqa: D105
         self.close()
 
     def _make_get_request(

--- a/signal_ocean/connection.py
+++ b/signal_ocean/connection.py
@@ -52,6 +52,16 @@ class Connection:
 
         return host if host.endswith("/") else host + "/"
 
+    def close(self) -> None:
+        """Close the underlying session and release connections."""
+        self.__session.close()
+
+    def __enter__(self) -> "Connection":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
     def _make_get_request(
         self, relative_url: str, query_string: Optional[QueryString] = None
     ) -> requests.Response:

--- a/signal_ocean/util/pydantic_base.py
+++ b/signal_ocean/util/pydantic_base.py
@@ -16,9 +16,14 @@ def _to_pascal_case(field_name: str) -> str:
     """Convert snake_case field name to PascalCase alias.
 
     Matches the Signal API naming convention where known acronyms ('id',
-    'imo', 'ais', 'coa', 'sts') are uppercased entirely rather than just
+    'imo', 'coa', 'pit', 'tpc') are uppercased entirely rather than just
     title-cased (e.g. vessel_class_id -> VesselClassID,
     vessel_type_id -> VesselTypeID, imo -> IMO).
+
+    Note: 'ais' is NOT in the acronyms set because the API is inconsistent
+    — some endpoints use 'AIS' (e.g. IsImpliedByAIS) while others use 'Ais'
+    (e.g. LowAisDensity). Fields needing 'AIS' should use explicit
+    validation_alias instead.
     """
     def _capitalize(word: str) -> str:
         if word.lower() in _ACRONYMS:

--- a/signal_ocean/vessels/models.py
+++ b/signal_ocean/vessels/models.py
@@ -518,15 +518,15 @@ class Vessel(SignalBaseModel):
     suez_canal_net_tonnage: Optional[int] = None
     class_renewal_date: Optional[UTCDatetime] = None
     mewis_duct: Optional[UTCDatetime] = None
-    inert_gas_system: Optional[bool] = None
-    imo_type_1: Optional[bool] = Field(None, validation_alias="IMOType1")
-    imo_type_2: Optional[bool] = Field(None, validation_alias="IMOType2")
-    imo_type_3: Optional[bool] = Field(None, validation_alias="IMOType3")
+    inert_gas_system: Optional[str] = None
+    imo_type_1: Optional[str] = Field(None, validation_alias="IMOType1")
+    imo_type_2: Optional[str] = Field(None, validation_alias="IMOType2")
+    imo_type_3: Optional[str] = Field(None, validation_alias="IMOType3")
     stst_coating: Optional[int] = Field(None, validation_alias="STSTCoating")
     epoxy_coating: Optional[int] = None
     zinc_coating: Optional[int] = None
     marineline_coating: Optional[int] = None
-    crude_oil_washing: Optional[bool] = None
+    crude_oil_washing: Optional[str] = None
     beneficial_owner_id: Optional[int] = None
     beneficial_owner: Optional[str] = None
     parallel_body_length: Optional[float] = None

--- a/signal_ocean/vessels/models.py
+++ b/signal_ocean/vessels/models.py
@@ -518,15 +518,15 @@ class Vessel(SignalBaseModel):
     suez_canal_net_tonnage: Optional[int] = None
     class_renewal_date: Optional[UTCDatetime] = None
     mewis_duct: Optional[UTCDatetime] = None
-    inert_gas_system: Optional[str] = None
-    imo_type_1: Optional[str] = Field(None, validation_alias="IMOType1")
-    imo_type_2: Optional[str] = Field(None, validation_alias="IMOType2")
-    imo_type_3: Optional[str] = Field(None, validation_alias="IMOType3")
+    inert_gas_system: Optional[bool] = None
+    imo_type_1: Optional[bool] = Field(None, validation_alias="IMOType1")
+    imo_type_2: Optional[bool] = Field(None, validation_alias="IMOType2")
+    imo_type_3: Optional[bool] = Field(None, validation_alias="IMOType3")
     stst_coating: Optional[int] = Field(None, validation_alias="STSTCoating")
     epoxy_coating: Optional[int] = None
     zinc_coating: Optional[int] = None
     marineline_coating: Optional[int] = None
-    crude_oil_washing: Optional[str] = None
+    crude_oil_washing: Optional[bool] = None
     beneficial_owner_id: Optional[int] = None
     beneficial_owner: Optional[str] = None
     parallel_body_length: Optional[float] = None


### PR DESCRIPTION
- Revert 5 fields in vessels/models.py from bool back to str to match the original API contract: inert_gas_system, imo_type_1/2/3, crude_oil_washing. These were Optional[str] before the pydantic migration and should not have been silently changed to Optional[bool].

- Fix _to_pascal_case docstring to match actual _ACRONYMS set (was listing 'ais' and 'sts' which are not in the set). Document why 'ais' is excluded: the API is inconsistent (LowAisDensity vs IsImpliedByAIS), so fields needing uppercase AIS must use explicit validation_alias.